### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ are satisfied.
 
 ## Installation
 
-You can install this on your system with a simple:
+You can install this on your system with:
 
 ```sh
-npx check-peer-deps
+npm i -g check-peer-deps
 ```
 
 Please note that this utility requires `npm` to be available.


### PR DESCRIPTION
It turns out that `npx` doesn't work the way that I was thinking it did. Although the previous instructions would _work_, they simply install a temporary copy of the utility. Change the instructions to recommend installing a permanent version.