### PR TITLE
Use native child_process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -292,14 +292,6 @@
         "typedarray": "0.0.6"
       }
     },
-    "consistent-env": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/consistent-env/-/consistent-env-1.3.1.tgz",
-      "integrity": "sha1-9oI018afxt2WVviuI0Kc4EmbZfs=",
-      "requires": {
-        "lodash.uniq": "4.5.0"
-      }
-    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -980,11 +972,6 @@
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
     },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -1344,35 +1331,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
-    },
-    "sb-exec": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sb-exec/-/sb-exec-4.0.0.tgz",
-      "integrity": "sha1-RnR/DfFiYmwW6/D+pCJFrRqoWco=",
-      "requires": {
-        "consistent-env": "1.3.1",
-        "lodash.uniq": "4.5.0",
-        "sb-npm-path": "2.0.0"
-      }
-    },
-    "sb-memoize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/sb-memoize/-/sb-memoize-1.0.2.tgz",
-      "integrity": "sha1-EoN1xi3bnMT/qQXQxaWXwZuurY4="
-    },
-    "sb-npm-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sb-npm-path/-/sb-npm-path-2.0.0.tgz",
-      "integrity": "sha1-D2zCzzcd68p9k27Xa31MPMHrPVg=",
-      "requires": {
-        "sb-memoize": "1.0.2",
-        "sb-promisify": "2.0.2"
-      }
-    },
-    "sb-promisify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sb-promisify/-/sb-promisify-2.0.2.tgz",
-      "integrity": "sha1-QnelR1RIiqlnXYhuNU24lMm9yYE="
     },
     "semver": {
       "version": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "dependencies": {
     "command-line-args": "^4.0.7",
     "command-line-usage": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "command-line-args": "^4.0.7",
     "command-line-usage": "^4.0.2",
-    "sb-exec": "^4.0.0",
     "semver": "^5.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Since this utility is meant to be run from a CLI environment, there is no need for the advanced environment fixing done in `sb-exec` to work around empty environments in GUI apps. Move to using the native `child_process` module directly, wrapped in a promise through `util.promisify`.

Fixes #15.