### PR TITLE
ci: add Travis CI configuration

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@ __tests__/*
 .circleci/*
 coverage/*
 .npmignore
+.travis.yml
 .gitignore
 .gitattributes
 .github_changelog_generator

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: node_js
+os: linux
+
+jobs:
+  include:
+    - stage: test
+      node_js: lts/*
+    - stage: test
+      node_js: node
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+branches:
+  only:
+    - master
+    - "/^greenkeeper/.*$/"
+
+git:
+  depth: 10
+
+dist: trusty
+
+sudo: false
+
+stages:
+  - test


### PR DESCRIPTION
Add a Travis CI configuration to test on that platform as it will enable easier use of some planned tools.