### PR TITLE
Run linting in CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ jobs:
       # Install the dependencies
       - run: npm install
 
+      # Lint the code
+      - run: npm run lint
+
       # run tests!
       - run: npm test
 

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage/*

--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@ __tests__/*
 coverage/*
 .gitattributes
 .gitignore
+.eslintignore
 .npmignore
 .travis.yml
 CHANGELOG.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jobs:
   include:
     - stage: test
       node_js: lts/*
+      before_script: npm run lint
     - stage: test
       node_js: node
 


### PR DESCRIPTION
Actually run the `lint` script in the CI builds, and ignore any coverage data when running ESLint.