### PR TITLE
checkPeerDependencies isn't actually async

### DIFF
--- a/check-peer-deps.js
+++ b/check-peer-deps.js
@@ -209,9 +209,8 @@ const getPeerDeps = async () => {
 };
 
 // peerDependencies checks
-const checkPeerDependencies = async (peerDependencies, name) => {
-  Promise.all(Array.from(peerDependencies.entries()).map(async (entry) => {
-    const [peerDepName, peerDepRange] = entry;
+const checkPeerDependencies = (peerDependencies, name) => {
+  peerDependencies.forEach((peerDepRange, peerDepName) => {
     log(`Checking ${name}'s peerDependency of '${peerDepName}@${peerDepRange}'`);
     let found = false;
     if (deps.has(peerDepName)) {
@@ -239,15 +238,11 @@ const checkPeerDependencies = async (peerDependencies, name) => {
         console.log(`Package dependencies can satisfy the peerDependency? ${maxUsable ? 'Yes' : 'No'}`);
       }
     }
-  }));
+  });
 };
 
-const checkAllPeerDeps = async () => {
-  const promises = [];
-  peerDeps.forEach((peerDependencies, name) => {
-    promises.push(checkPeerDependencies(peerDependencies, name));
-  });
-  return Promise.all(promises);
+const checkAllPeerDeps = () => {
+  peerDeps.forEach(checkPeerDependencies);
 };
 
 const findDependencies = async () => {
@@ -304,7 +299,7 @@ async function checkPeerDeps() {
     log('');
 
     log('Checking versions...');
-    await checkAllPeerDeps();
+    checkAllPeerDeps();
     log('Done.');
   }
 }


### PR DESCRIPTION
Although at some point in the past of the design of this `checkPeerDependencies` function needed to be `async`, the current code does all of the `async` data gathering work before this method is called. Remove the complexity added to allow this to be async.

While reviewing the lint changes in another project I realized that the changes in https://github.com/Arcanemagus/check-peer-deps/commit/6e5b28aa36bcc961ff3291f3bfb479cfafa54c55 from #43 would have broken things here if this function was really `async`, so I investigated and found this PR was necessary.